### PR TITLE
Address G++ compile warnings

### DIFF
--- a/libgfx/src/raster.cxx
+++ b/libgfx/src/raster.cxx
@@ -45,8 +45,8 @@ FloatRaster::FloatRaster(const FloatRaster &img)
 
 
 
-static char *img_names[] = {"PPM", "PNG", "TIFF", "JPEG"};
-static char *img_ext[] = {"ppm", "png", "tif", "jpg"};
+static const char *img_names[] = {"PPM", "PNG", "TIFF", "JPEG"};
+static const char *img_ext[] = {"ppm", "png", "tif", "jpg"};
 
 const char *image_type_name(int type)
 	{ return type>=IMG_LIMIT ? NULL : img_names[type]; }

--- a/src/canvas_base.cc
+++ b/src/canvas_base.cc
@@ -60,15 +60,11 @@ int CanvasBase::loop()
 	int remain, ret;
 	last_tick = get_ms();
 
-	int first_tick = get_ms();
-
 	while (true) {
 		if ((remain = tick()) > 0) // time left till tick: sleep
 			delay(remain);
 		if ((ret = handle_events()) > 0) // wants us to quit
 			return ret;
-//		if (last_tick - first_tick > 10000)
-//			return ret;
 	}
 }
 

--- a/src/canvas_sdl.cc
+++ b/src/canvas_sdl.cc
@@ -9,7 +9,7 @@
 
 using namespace std;
 
-CanvasSDL::CanvasSDL(Scene *s, bool fs, int m, char *t, char *c)
+CanvasSDL::CanvasSDL(Scene *s, bool fs, int m, const char *t, const char *c)
     : CanvasBase(s, fs, m), wm_title(t), wm_class(c)
 {
     surface = 0;

--- a/src/canvas_sdl.h
+++ b/src/canvas_sdl.h
@@ -9,13 +9,13 @@
 class CanvasSDL : public CanvasBase {
 protected:
     SDL_Surface *surface;
-    char *wm_title;
-    char *wm_class;
+    const char *wm_title;
+    const char *wm_class;
 
     // create the window (either SDL or GLX)
     virtual int create_window();
 public:
-    CanvasSDL(Scene *s, bool full_screen, int mspf, char *wm_title, char *wm_class);
+    CanvasSDL(Scene *s, bool full_screen, int mspf, const char *wm_title, const char *wm_class);
     virtual ~CanvasSDL() {}
 
     // resize the viewport and apply frustum transformation

--- a/src/main.cc
+++ b/src/main.cc
@@ -21,7 +21,7 @@
 CanvasBase *canvas;
 Scene scene;
 
-enum {CANVAS_SDL, CANVAS_GLX} canvas_type = CANVAS_SDL;
+static enum {CANVAS_SDL, CANVAS_GLX} canvas_type = CANVAS_SDL;
 int window_id = 0;
 int mspf = 1000/30;
 bool full_screen = false;
@@ -187,7 +187,7 @@ int argp_parse(struct argp *argp_s, int argc, char *argv[], int, int *, void *)
 #define OPT_FPS 2
 #define OPT_FASTFORWARD 3
 
-char *mode_help =
+const char * const mode_help =
 "\n"
 "Per-swarm modes and their default probabilities:\n"
 "  1: normal                                         p=20\n"

--- a/src/main.h
+++ b/src/main.h
@@ -1,9 +1,18 @@
 #ifndef _MAIN_H
 #define _MAIN_H
 
-#include "../config.h"
 
 #include <gfx/config.h> // libgfx is retarded
+
+// Suppress re-definition warnings
+#undef PACKAGE_BUGREPORT
+#undef PACKAGE_NAME
+#undef PACKAGE_STRING
+#undef PACKAGE_TARNAME
+#undef PACKAGE_VERSION
+
+#include "../config.h"
+
 #include <GL/gl.h>
 
 using namespace std;

--- a/src/vroot.h
+++ b/src/vroot.h
@@ -97,7 +97,7 @@ VirtualRootWindowOfScreen(screen) Screen *screen;
 	if (screen != save_screen) {
 		Display *dpy = DisplayOfScreen(screen);
 		Atom __SWM_VROOT = None;
-		int i;
+		unsigned int i;
 		Window rootReturn, parentReturn, *children;
 		unsigned int numChildren;
 


### PR DESCRIPTION
- on re-definition of PACKAGE_\* defines
- "anonymous type with no linkage used to declare variable"

main.cc:24:31: warning: anonymous type with no linkage used to declare variable ‘<anonymous enum> canvas_type’ with linkage [enabled by default]
 enum {CANVAS_SDL, CANVAS_GLX} canvas_type = CANVAS_SDL;
                               ^
- "deprecated conversion from string constant to ‘char*’"

main.cc:209:1: warning: deprecated conversion from string constant to ‘char*’ [-Wwrite-strings]
 "p=1, that simply means A is 5 times more likely to occur than B.";
 ^

main.cc:380:76: warning: deprecated conversion from string constant to ‘char*’ [-Wwrite-strings]
  canvas = new CanvasSDL(&scene, full_screen, mspf, "Fireflies", "fireflies");
                                                                            ^
- "comparison between signed and unsigned integer expressions"

vroot.h:123:20: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
    for (i = 0; i < numChildren; i++) {
                    ^
- "deprecated conversion from string constant to ‘char*’"

raster.cxx:48:57: warning: deprecated conversion from string constant to ‘char_’ [-Wwrite-strings]
 static char *img_names[] = {"PPM", "PNG", "TIFF", "JPEG"};
                                                         ^
raster.cxx:48:57: warning: deprecated conversion from string constant to ‘char_’ [-Wwrite-strings]
raster.cxx:48:57: warning: deprecated conversion from string constant to ‘char_’ [-Wwrite-strings]
raster.cxx:48:57: warning: deprecated conversion from string constant to ‘char_’ [-Wwrite-strings]
raster.cxx:49:53: warning: deprecated conversion from string constant to ‘char_’ [-Wwrite-strings]
 static char *img_ext[] = {"ppm", "png", "tif", "jpg"};
                                                     ^
raster.cxx:49:53: warning: deprecated conversion from string constant to ‘char_’ [-Wwrite-strings]
raster.cxx:49:53: warning: deprecated conversion from string constant to ‘char_’ [-Wwrite-strings]
raster.cxx:49:53: warning: deprecated conversion from string constant to ‘char_’ [-Wwrite-strings]
- Resolve unused variable (and related dead code)

canvas_base.cc:63:6: warning: unused variable ‘first_tick’ [-Wunused-variable]
  int first_tick = get_ms();
      ^
