### PR TITLE
debian: Get dependencies back in sync with code

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,8 +4,8 @@ Priority: extra
 Maintainer: Sebastian Pipping <sebastian@pipping.org>
 # autoconf-archive for AX_CXX_BOOL autoconf macro
 Build-Depends: debhelper (>= 8.0.0),
- autoconf-archive,
- libx11-dev, libsdl1.2-dev, libglu1-mesa-dev, mesa-common-dev
+ autoconf-archive, freeglut3-dev, libglew-dev,
+ libx11-dev, libglu1-mesa-dev, mesa-common-dev
 Standards-Version: 3.9.3
 Homepage: https://github.com/mpcomplete/fireflies
 Vcs-Git: https://github.com/mpcomplete/fireflies


### PR DESCRIPTION
For #19 and #20.

SDL is dropped due to 0f73116b1d25dd19df17f449f718d2d79838d31a .
GLUT is added for 2452de62e7cda5755b3f37c567edbc60946a3baa .
GLEW for 1c5f28cba08a53e4b8206d02b5fcd856b26a4c3d .